### PR TITLE
Add deno flake

### DIFF
--- a/deno/flake.nix
+++ b/deno/flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "A basic deno flake";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in {
+        devShell = pkgs.mkShell {
+          buildInputs = [
+            pkgs.deno
+          ];
+        };
+      });
+}


### PR DESCRIPTION
This PR adds a super simple deno flake. It does nothing else but add deno as a buildInput. No I'm not spending that time to make a near-equivalent flake for NodeJS :P